### PR TITLE
Add Chinese Laoshi to projects

### DIFF
--- a/components/SideProjects.tsx
+++ b/components/SideProjects.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from 'next-intl';
 
-const projects = ['lulight'] as const;
+const projects = ['chinese-laoshi', 'lulight'] as const;
 
 export default function SideProjects() {
   const t = useTranslations();
@@ -27,6 +27,11 @@ export default function SideProjects() {
               <a href={t(`projects.${project}.url`)} className='text-link' target='_blank' rel='noopener noreferrer'>
                 {t('projects.view-project')}
               </a>
+              {t.has(`projects.${project}.github`) && (
+                <a href={t(`projects.${project}.github`)} className='text-link' target='_blank' rel='noopener noreferrer'>
+                  {t('projects.view-github')}
+                </a>
+              )}
             </div>
           </li>
         ))}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -40,6 +40,13 @@
   "projects": {
     "title": "Projects",
     "view-project": "View project",
+    "view-github": "GitHub",
+    "chinese-laoshi": {
+      "name": "Chinese Laoshi",
+      "description": "Mandarin learning app with interactive flashcards — handwriting practice and translation guessing. Built with React, TypeScript, and Go; works on phone, tablet, and desktop.",
+      "url": "https://chineselaoshi.slavoyar.tech",
+      "github": "https://github.com/slavoyar/ChineseLaoshi"
+    },
     "lulight": {
       "name": "Production E-Commerce Platform (Clothing Brand - Lulight)",
       "description": "Built a full-stack online store from scratch using Next.js, handling 200+ SKUs and processing 50+ orders/month. Integrated payment gateway with webhook handling for order confirmation, reducing manual order processing time by 80%.",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -40,6 +40,13 @@
   "projects": {
     "title": "Проекты",
     "view-project": "Посмотреть проект",
+    "view-github": "GitHub",
+    "chinese-laoshi": {
+      "name": "Chinese Laoshi",
+      "description": "Приложение для изучения китайского с интерактивными карточками — режим рукописного ввода и угадывания перевода. React, TypeScript и Go; работает на телефоне, планшете и десктопе.",
+      "url": "https://chineselaoshi.slavoyar.tech",
+      "github": "https://github.com/slavoyar/ChineseLaoshi"
+    },
     "lulight": {
       "name": "Продакшн e-commerce платформа (бренд одежды — Lulight)",
       "description": "Разработал full-stack интернет-магазин с нуля на Next.js: 200+ SKU, 50+ заказов в месяц. Интегрировал платёжный шлюз с webhook-обработкой для подтверждения заказов, сократив время ручной обработки заказов на 80%.",


### PR DESCRIPTION
## Summary
- Add Chinese Laoshi to the Projects section with live site and GitHub links
- Support optional GitHub link in project entries (Lulight unchanged)
- Add EN/RU copy for the new project

## Test plan
- [x] Open portfolio locally and confirm Chinese Laoshi appears first under Projects
- [x] Verify View project links to https://chineselaoshi.slavoyar.tech
- [x] Verify GitHub links to https://github.com/slavoyar/ChineseLaoshi
- [x] Confirm Lulight still shows only View project
- [x] Spot-check RU locale for Chinese Laoshi copy
