### PR TITLE
Fix Prettier lint blocking deploy for Chinese Laoshi

### DIFF
--- a/components/SideProjects.tsx
+++ b/components/SideProjects.tsx
@@ -28,7 +28,12 @@ export default function SideProjects() {
                 {t('projects.view-project')}
               </a>
               {t.has(`projects.${project}.github`) && (
-                <a href={t(`projects.${project}.github`)} className='text-link' target='_blank' rel='noopener noreferrer'>
+                <a
+                  href={t(`projects.${project}.github`)}
+                  className='text-link'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
                   {t('projects.view-github')}
                 </a>
               )}


### PR DESCRIPTION
## Summary
- Fix `prettier/prettier` formatting on the GitHub link in `SideProjects.tsx`
- Unblocks `next build` / Docker deploy after #4 merged with a failing CI build

## Test plan
- [x] CI Docker build succeeds (`npm run build`)
- [x] Confirm Chinese Laoshi still shows View project + GitHub links
